### PR TITLE
fix unicode character in injected javascript issue

### DIFF
--- a/src/android/RemoteInjectionPlugin.java
+++ b/src/android/RemoteInjectionPlugin.java
@@ -138,7 +138,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
             jsToInject.append(readFile(cordova.getActivity().getResources().getAssets(), path));
         }
         String jsUrl = "javascript:var script = document.createElement('script');";
-        jsUrl += "script.src=\"data:text/javascript;base64,";
+        jsUrl += "script.src=\"data:text/javascript;charset=utf-8;base64,";
 
         jsUrl += Base64.encodeToString(jsToInject.toString().getBytes(), Base64.DEFAULT);
         jsUrl += "\";";


### PR DESCRIPTION
As [Data Url Scheme description](https://en.wikipedia.org/wiki/Data_URI_scheme) the default charset in data URI is US-ASCII,  so to fix the issue #13  just change the charset to utf-8 as the documentation said.