### PR TITLE
Update CDVRemoteInjectionWebViewBaseDelegate.m

### DIFF
--- a/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
+++ b/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
@@ -215,6 +215,10 @@
 {
     NSLog(@"Error loading page: %@", [error description]);
     
+    if ([error code] == NSURLErrorCancelled) { //ignore if page load didn't complete and user moved away to another page
+        return;
+    }
+
     if (userRequestedReload == NO && self.plugin.showConnectionErrorDialog == YES) {
         [self displayRetryPromptWithMessage:@"Unable to contact the site." withCancelText:@"Close" retryable:NO];
     }


### PR DESCRIPTION
NSURLErrorCancelled error should be ignored. When it is not ignored, we get the error dialog when we click on a link and page has not completed loading.