### PR TITLE
fix unexpected token error caused by the default base64 encoding

### DIFF
--- a/src/android/RemoteInjectionPlugin.java
+++ b/src/android/RemoteInjectionPlugin.java
@@ -140,7 +140,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
         String jsUrl = "javascript:var script = document.createElement('script');";
         jsUrl += "script.src=\"data:text/javascript;charset=utf-8;base64,";
 
-        jsUrl += Base64.encodeToString(jsToInject.toString().getBytes(), Base64.DEFAULT);
+        jsUrl += Base64.encodeToString(jsToInject.toString().getBytes(), Base64.NO_WRAP);
         jsUrl += "\";";
 
         jsUrl += "document.getElementsByTagName('head')[0].appendChild(script);";


### PR DESCRIPTION
The line wrapping of the default base64 encoding settings was causing an "Unexpected token" error. The NO_WRAP flags looks like a sensible way to encode the scripts.

Thank you for writting the plugin! :+1: 