### PR TITLE
Injectable URLs and check window to ensure Cordova is not already defined 

### DIFF
--- a/src/android/RemoteInjectionPlugin.java
+++ b/src/android/RemoteInjectionPlugin.java
@@ -4,7 +4,11 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.res.AssetManager;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.util.Base64;
+import android.util.Log;
+import android.webkit.ValueCallback;
 
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebViewEngine;
@@ -37,16 +41,16 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
 
     protected void pluginInitialize() {
         String pref = webView.getPreferences().getString("CRIInjectFirstFiles", "");
-        for (String path: pref.split(",")) {
+        for (String path : pref.split(",")) {
             preInjectionFileNames.add(path.trim());
         }
 
-        String sites = webView.getPreferences().getString("CRIInjectableSites","");
-        for (String site: pref.split(",")) {
+        String sites = webView.getPreferences().getString("CRIInjectableSites", "");
+        for (String site : sites.split(",")) {
             injectableSites.add(site.trim());
         }
 
-        promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 10);
+        promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 30);
 
         final Activity activity = super.cordova.getActivity();
         final CordovaWebViewEngine engine = super.webView.getEngine();
@@ -57,13 +61,14 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
         LOG.e(TAG, messageId + " received a data instance that is not an expected type:" + data.getClass().getName());
     }
 
-    private bool isInjectableSite(String site){
-        if(injectableSites.Size() <= 0){
+    private boolean isInjectableSite(String site) {
+        if (injectableSites.size() <= 0) {
             return true;
         }
-        for(String availableSite: injectableSites){
-            Pattern sitePattern = Pattern.compile("^"+availableSite);
-            if(sitePattern.matcher((String) site)){
+        for (String availableSite : injectableSites) {
+            String regex = "^" + availableSite.replace("*", ".*");
+            Pattern sitePattern = Pattern.compile(regex);
+            if (sitePattern.matcher(site).matches()) {
                 return true;
             }
         }
@@ -132,39 +137,53 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
     }
 
     private void injectCordova() {
-        List<String> jsPaths = new ArrayList<String>();
-        for (String path: preInjectionFileNames) {
-            jsPaths.add(path);
-        }
+        webView.getEngine().evaluateJavascript("window.cordova", new ValueCallback<String>() {
+            @Override
+            public void onReceiveValue(String value) {
+                if (value.equalsIgnoreCase("null")) {
+                    List<String> jsPaths = new ArrayList<String>();
+                    for (String path : preInjectionFileNames) {
+                        jsPaths.add(path);
+                    }
 
-        jsPaths.add("www/cordova.js");
+                    jsPaths.add("www/cordova.js");
 
-        // We load the plugin code manually rather than allow cordova to load them (via
-        // cordova_plugins.js).  The reason for this is the WebView will attempt to load the
-        // file in the origin of the page (e.g. https://truckmover.com/plugins/plugin/plugin.js).
-        // By loading them first cordova will skip its loading process altogether.
-        jsPaths.addAll(jsPathsToInject(cordova.getActivity().getResources().getAssets(), "www/plugins"));
+                    // We load the plugin code manually rather than allow cordova to load them (via
+                    // cordova_plugins.js).  The reason for this is the WebView will attempt to load the
+                    // file in the origin of the page (e.g. https://truckmover.com/plugins/plugin/plugin.js).
+                    // By loading them first cordova will skip its loading process altogether.
+                    jsPaths.addAll(jsPathsToInject(cordova.getActivity().getResources().getAssets(), "www/plugins"));
 
-        // Initialize the cordova plugin registry.
-        jsPaths.add("www/cordova_plugins.js");
+                    // Initialize the cordova plugin registry.
+                    jsPaths.add("www/cordova_plugins.js");
 
-        // The way that I figured out to inject for android is to inject it as a script
-        // tag with the full JS encoded as a data URI
-        // (https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs).  The script tag
-        // is appended to the DOM and executed via a javascript URL (e.g. javascript:doJsStuff()).
-        StringBuilder jsToInject = new StringBuilder();
-        for (String path: jsPaths) {
-            jsToInject.append(readFile(cordova.getActivity().getResources().getAssets(), path));
-        }
-        String jsUrl = "javascript:var script = document.createElement('script');";
-        jsUrl += "script.src=\"data:text/javascript;charset=utf-8;base64,";
+                    // The way that I figured out to inject for android is to inject it as a script
+                    // tag with the full JS encoded as a data URI
+                    // (https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs).  The script tag
+                    // is appended to the DOM and executed via a javascript URL (e.g. javascript:doJsStuff()).
+                    StringBuilder jsToInject = new StringBuilder();
+                    for (String path : jsPaths) {
+                        jsToInject.append(readFile(cordova.getActivity().getResources().getAssets(), path));
+                    }
+                    String jsUrl = "javascript:var script = document.createElement('script');";
+                    jsUrl += "script.src=\"data:text/javascript;charset=utf-8;base64,";
 
-        jsUrl += Base64.encodeToString(jsToInject.toString().getBytes(), Base64.NO_WRAP);
-        jsUrl += "\";";
+                    jsUrl += Base64.encodeToString(jsToInject.toString().getBytes(), Base64.NO_WRAP);
+                    jsUrl += "\";";
 
-        jsUrl += "document.getElementsByTagName('head')[0].appendChild(script);";
+                    jsUrl += "document.getElementsByTagName('head')[0].appendChild(script);";
 
-        webView.getEngine().loadUrl(jsUrl, false);
+                    webView.getEngine().evaluateJavascript(jsUrl, new ValueCallback<String>() {
+                        @Override
+                        public void onReceiveValue(String value) {
+                            Log.d(TAG, value);
+                        }
+                    });
+                } else {
+                    Log.d(TAG, "Cordova already defined");
+                }
+            }
+        });
     }
 
     private String readFile(AssetManager assets, String filePath) {
@@ -197,14 +216,14 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
      * Searches the provided path for javascript files recursively.
      *
      * @param assets
-     * @param path start path
+     * @param path   start path
      * @return found JS files
      */
-    private List<String> jsPathsToInject(AssetManager assets, String path){
+    private List<String> jsPathsToInject(AssetManager assets, String path) {
         List jsPaths = new ArrayList<String>();
 
         try {
-            for (String filePath: assets.list(path)) {
+            for (String filePath : assets.list(path)) {
                 String fullPath = path + File.separator + filePath;
 
                 if (fullPath.endsWith(".js")) {
@@ -259,7 +278,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
                 task.cancel();
             }
 
-            if (promptInterval > 0 ) {
+            if (promptInterval > 0) {
                 task = new UserPromptTask(this, activity, engine, url);
                 new Timer().schedule(task, promptInterval * 1000);
             }
@@ -304,6 +323,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
             if (lifecycle.isLoading()) {
                 // Prompts the user giving them the choice to wait on the current request or retry.
                 lifecycle.activity.runOnUiThread(new Runnable() {
+                    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
                     @Override
                     public void run() {
                         AlertDialog.Builder builder = new AlertDialog.Builder(activity);

--- a/src/android/RemoteInjectionPlugin.java
+++ b/src/android/RemoteInjectionPlugin.java
@@ -50,7 +50,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
             injectableSites.add(site.trim());
         }
 
-        promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 30);
+        promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 10);
 
         final Activity activity = super.cordova.getActivity();
         final CordovaWebViewEngine engine = super.webView.getEngine();

--- a/src/ios/CDVRemoteInjection.h
+++ b/src/ios/CDVRemoteInjection.h
@@ -18,6 +18,8 @@ is set to 0.
  */
 @property (readonly) BOOL showConnectionErrorDialog;
     
+@property (readonly) NSArray *injectableSites;
+    
 - (id) findWebView;
 @end
 

--- a/src/ios/CDVRemoteInjection.m
+++ b/src/ios/CDVRemoteInjection.m
@@ -79,6 +79,17 @@
         // By default the dialog is displayed.
         _showConnectionErrorDialog = YES;
     }
+    
+    value = [self settingForKey:@"CRIInjectableSites"];
+    if (value != NULL){
+        NSMutableArray *sites = [[NSMutableArray alloc] init];
+        for (id site in [value componentsSeparatedByString:@","]) {
+            [sites addObject: [self trim: site]];
+        }
+        _injectableSites = sites;
+    } else {
+        _injectableSites = [[NSArray alloc] init];
+    }
 
     id webView = [self findWebView];
     if ([webView isKindOfClass:[UIWebView class]]) {

--- a/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
+++ b/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
@@ -72,7 +72,8 @@
     // Inject cordova into the page.
     NSString *scheme = webView.request.URL.scheme;
  
-    if ([self isSupportedURLScheme:scheme]){
+    if ([self isSupportedURLScheme:scheme] && [self isInjectableSite:webView.request.URL.absoluteString]){
+        NSLog(@"Evaluating Javascript for %@",webView.request.URL.absoluteString);
         [webView stringByEvaluatingJavaScriptFromString:[self buildInjectionJS]];
     }
 }

--- a/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
+++ b/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
@@ -74,7 +74,12 @@
  
     if ([self isSupportedURLScheme:scheme] && [self isInjectableSite:webView.request.URL.absoluteString]){
         NSLog(@"Evaluating Javascript for %@",webView.request.URL.absoluteString);
-        [webView stringByEvaluatingJavaScriptFromString:[self buildInjectionJS]];
+        NSString *response = [webView stringByEvaluatingJavaScriptFromString: @"window.cordova"];
+        if ([response caseInsensitiveCompare: @"null"] != NSOrderedSame){
+            [webView stringByEvaluatingJavaScriptFromString:[self buildInjectionJS]];
+        }else{
+            NSLog(@"Cordova already defined.");
+        }
     }
 }
 

--- a/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
+++ b/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
@@ -74,8 +74,8 @@
  
     if ([self isSupportedURLScheme:scheme] && [self isInjectableSite:webView.request.URL.absoluteString]){
         NSLog(@"Evaluating Javascript for %@",webView.request.URL.absoluteString);
-        NSString *response = [webView stringByEvaluatingJavaScriptFromString: @"window.cordova"];
-        if ([response caseInsensitiveCompare: @"null"] != NSOrderedSame){
+        NSString *response = [webView stringByEvaluatingJavaScriptFromString: @"window.cordova == null"];
+        if ([response caseInsensitiveCompare: @"false"] != NSOrderedSame){
             [webView stringByEvaluatingJavaScriptFromString:[self buildInjectionJS]];
         }else{
             NSLog(@"Cordova already defined.");

--- a/src/ios/CDVRemoteInjectionWKWebViewDelegate.m
+++ b/src/ios/CDVRemoteInjectionWKWebViewDelegate.m
@@ -77,7 +77,7 @@
     
     NSString *scheme = webView.URL.scheme;
 
-    if ([self isSupportedURLScheme:scheme]) {
+    if ([self isSupportedURLScheme:scheme] && [self isInjectableSite:webView.URL.absoluteString]) {
         [webView evaluateJavaScript:[self buildInjectionJS] completionHandler:^(id id, NSError *error){
             if (error) {
                 // Nothing to do here other than log the error.

--- a/src/ios/CDVRemoteInjectionWKWebViewDelegate.m
+++ b/src/ios/CDVRemoteInjectionWKWebViewDelegate.m
@@ -78,11 +78,21 @@
     NSString *scheme = webView.URL.scheme;
 
     if ([self isSupportedURLScheme:scheme] && [self isInjectableSite:webView.URL.absoluteString]) {
-        [webView evaluateJavaScript:[self buildInjectionJS] completionHandler:^(id id, NSError *error){
-            if (error) {
-                // Nothing to do here other than log the error.
-                NSLog(@"Error when injecting javascript into WKWebView: '%@'.", error);
+        [webView evaluateJavaScript:@"window.cordova == null" completionHandler:^(id result, NSError *error){
+            if (result != nil) {
+                NSString *resultString = [NSString stringWithFormat:@"%@", result];
+                if([resultString caseInsensitiveCompare:@"0"] != NSOrderedSame){
+                    [webView evaluateJavaScript:[self buildInjectionJS] completionHandler:^(id result, NSError *error){
+                        if (error) {
+                            // Nothing to do here other than log the error.
+                            NSLog(@"Error when injecting javascript into WKWebView: '%@'.", error);
+                        }
+                    }];
+                }else{
+                    NSLog(@"Cordova has already been defined");
+                }
             }
+
         }];
     }
 }

--- a/src/ios/CDVRemoteInjectionWebViewBaseDelegate.h
+++ b/src/ios/CDVRemoteInjectionWebViewBaseDelegate.h
@@ -11,6 +11,7 @@
 - (NSArray *) jsPathsToInject;
 - (NSString *) buildInjectionJS;
 - (BOOL) isSupportedURLScheme:(NSString *) scheme;
+- (BOOL) isInjectableSite:(NSString *) site;
 - (void) cancelRequestTimer;
 - (void) retryCurrentRequest;
 - (void) webViewRequestStart;

--- a/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
+++ b/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
@@ -1,294 +1,106 @@
+//
+//  CDVRemoteInjection.m
+//
+
 #import <Foundation/Foundation.h>
 
-#import "CDVRemoteInjection.h"
+#import "CDVRemoteInjectionUIWebViewDelegate.h"
 #import "CDVRemoteInjectionWebViewBaseDelegate.h"
 
-/*
- Objective-C wonkiness to create a property that can be accessed
- by subclasses but not on the exported public interface.
- */
-@interface CDVRemoteInjectionWebViewBaseDelegate ()
-@property (readwrite, weak) CDVRemoteInjectionPlugin *plugin;
-@end
 
-@interface CDVRemoteInjectionWebViewBaseDelegate ()
-@end
+@implementation CDVRemoteInjectionUIWebViewNotificationDelegate
+@dynamic wrappedDelegate;
 
-@implementation WrappedDelegateProxy
-- (BOOL)respondsToSelector:(SEL)aSelector
+- (void)webViewDidStartLoad:(UIWebView*)webView
 {
-    if ([super respondsToSelector:aSelector] || [self.wrappedDelegate respondsToSelector:aSelector]) {
-        return YES;
+    [self.webViewDelegate onWebViewDidStartLoad];
+
+    if ([self.wrappedDelegate respondsToSelector:@selector(webViewDidStartLoad:)]) {
+        [self.wrappedDelegate webViewDidStartLoad:webView];
     }
-    return NO;
 }
 
-- (void)forwardInvocation:(NSInvocation *)anInvocation
+- (void)webViewDidFinishLoad:(UIWebView *)webView
 {
-    if ([self.wrappedDelegate respondsToSelector:[anInvocation selector]])
-        [anInvocation invokeWithTarget:self.wrappedDelegate];
-    else
-        [super forwardInvocation:anInvocation];
+    [self.webViewDelegate onWebViewDidFinishLoad:webView];
+
+    if ([self.wrappedDelegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
+        [self.wrappedDelegate webViewDidFinishLoad:webView];
+    }
+}
+
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+    if ([self.wrappedDelegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
+        [self.wrappedDelegate webView:webView didFailLoadWithError:error];
+    }
+
+    [self.webViewDelegate onWebViewFailLoadWithError:error];
 }
 @end
 
-@implementation CDVRemoteInjectionWebViewBaseDelegate
+@implementation CDVRemoteInjectionUIWebViewDelegate
 {
-    /*
-     Last time a request was made to load the web view.  Can be NULL.
-     */
-    NSDate *lastRequestTime;
-    
-    /*
-     Reference to the currently displayed alert view.  Can be NULL.
-     */
-    UIAlertView *alertView;
-    
-    /*
-     True if the user forced a reload.
-     */
-    BOOL userRequestedReload;
+    CDVRemoteInjectionUIWebViewNotificationDelegate *notificationDelegate;
 }
 
 - (void)initializeDelegate:(CDVRemoteInjectionPlugin *)plugin
 {
-  // TODO To placate the compiler.
+    self.plugin = plugin;
+
+    // Wrap the current delegate with our own so we can hook into web view events.
+    UIWebView *uiWebView = [plugin findWebView];
+    notificationDelegate = [[CDVRemoteInjectionUIWebViewNotificationDelegate alloc] init];
+    notificationDelegate.wrappedDelegate = [uiWebView delegate];
+    notificationDelegate.webViewDelegate = self;
+    [uiWebView setDelegate:notificationDelegate];
+}
+
+-(void) onWebViewDidStartLoad
+{
+    [super webViewRequestStart];
 }
 
 /*
- Builds a string of JS to inject into the web view.
+ * After page load inject cordova and its plugins.
  */
-- (NSString *) buildInjectionJS;
+- (void) onWebViewDidFinishLoad:(UIWebView *)webView
 {
-    NSArray *jsPaths = [self jsPathsToInject];
-    
-    NSString *path;
-    NSMutableString *concatenatedJS = [[NSMutableString alloc] init];
-    
-    for (path in jsPaths) {
-        NSString *jsFilePath = [[NSBundle mainBundle] pathForResource:path ofType:nil];
-        
-        NSURL *jsURL = [NSURL fileURLWithPath:jsFilePath];
-        NSString *js = [NSString stringWithContentsOfFile:jsURL.path encoding:NSUTF8StringEncoding error:nil];
-        NSLog(@"Concatenating JS found in path: '%@'", jsURL.path);
-        
-        [concatenatedJS appendString:js];
-    }
-    return concatenatedJS;
-}
+    // Cancel the slow request timer.
+    [self cancelRequestTimer];
 
-/*
- Returns an array of bundled javascript files to inject into the current page.
- */
-- (NSArray *) jsPathsToInject
-{
-    // Array of paths that represent JS files to inject into the WebView.  Order is important.
-    NSMutableArray *jsPaths = [NSMutableArray new];
-    
-    // Pre injection files.
-    for (id path in self.plugin.injectFirstFiles) {
-        [jsPaths addObject: path];
-    }
-    
-    [jsPaths addObject:@"www/cordova.js"];
-    
-    // We load the plugin code manually rather than allow cordova to load them (via
-    // cordova_plugins.js).  The reason for this is the WebView will attempt to load the
-    // file in the origin of the page (e.g. https://example.com/plugins/plugin/plugin.js).
-    // By loading them first cordova will skip the loading process altogether.
-    NSDirectoryEnumerator *directoryEnumerator = [[NSFileManager defaultManager] enumeratorAtPath:[[NSBundle mainBundle] pathForResource:@"www/plugins" ofType:nil]];
-    
-    NSString *path;
-    while (path = [directoryEnumerator nextObject])
-    {
-        if ([path hasSuffix: @".js"]) {
-            [jsPaths addObject: [NSString stringWithFormat:@"%@/%@", @"www/plugins", path]];
-        }
-    }
-    // Initialize cordova plugin registry.
-    [jsPaths addObject:@"www/cordova_plugins.js"];
-    
-    return jsPaths;
-}
+    // Inject cordova into the page.
+    NSString *scheme = webView.request.URL.scheme;
 
-/*
- * Returns YES if the URL scheme is supported for JS injection.
- *
- * TODO: possibly expand to check content type
- */
-- (BOOL) isSupportedURLScheme:(NSString *) scheme
-{
-    if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
-        return YES;
-    }
-    
-    NSLog(@"Unsupported scheme for cordova injection: '%@'.  Skipping.", scheme);
-    return NO;
-}
-    
-    
-/*
- * Returns YES if is valid URL
- *
- */
-- (BOOL) isInjectableSite:(NSString *) url
-{
-    // If no injectable sites, return yes by default
-    if([self.plugin.injectableSites count] <= 0){
-        return YES;
-    }
-    // Available Sites
-    for (id site in self.plugin.injectableSites) {
-        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: site options: NSRegularExpressionCaseInsensitive error: nil];
-        NSTextCheckingResult *match = [regex firstMatchInString:url options:NSMatchingReportCompletion range: NSMakeRange(0, [site length])];
-        BOOL isMatch = match != nil;
-        if(isMatch){
-            return YES;
-        }
-    }
-    return NO;
-}
-    
-    
-/*
- * Begins a timer to track the progress of a request.
- */
--(void) startRequestTimer
-{
-    if (self.plugin.promptInterval > 0) {
-        [self cancelRequestTimer];
-        lastRequestTime = [NSDate date];
-        
-        // Schedule progress check.
-        NSLog(@"Starting a timer to track page load time that will expire in '%ld' seconds.", (long)self.plugin.promptInterval);
-        [self performSelector:@selector(loadProgressCheckCallback:) withObject:lastRequestTime afterDelay:self.plugin.promptInterval];
-    }
-}
-
-/*
- * Determines if the user should be prompted because of a long running request.  Displays the prompt.
- */
--(void) loadProgressCheckCallback:(id)requestTime
-{
-    // Check equality of the request time to ensure we're still tracking the same request.  If not ignore.
-    if (lastRequestTime != NULL && [(NSDate *)requestTime isEqualToDate:lastRequestTime]) {
-        if ([self isLoading]) {
-            NSLog(@"Request taking too long, displaying dialog.");
-            [self displayRetryPromptWithMessage:@"The server is taking longer than expected to respond." withCancelText:@"Wait" retryable:YES];
-            return;
-        } else {
-            NSLog(@"No request in progress.  Not displaying dialog.");
+    if ([self isSupportedURLScheme:scheme] && [self isInjectableSite:webView.request.URL.absoluteString]){
+        NSLog(@"Evaluating Javascript for %@",webView.request.URL.absoluteString);
+        NSString *response = [webView stringByEvaluatingJavaScriptFromString: @"window.cordova"];
+        if ([response caseInsensitiveCompare: @"null"] != NSOrderedSame){
+            [webView stringByEvaluatingJavaScriptFromString:[self buildInjectionJS]];
+        }else{
+            NSLog(@"Cordova already defined.");
         }
     }
 }
 
-/*
- Prompts the user providing them a choice to retry the latest request or wait.
- */
--(void) displayRetryPromptWithMessage:(NSString*)message withCancelText:(NSString *)cancelText retryable:(BOOL) retry
+// Handles notifications from the webview delegate whenever a page load fails.
+- (void) onWebViewFailLoadWithError:(NSError *)error
 {
-    alertView = [[UIAlertView alloc] initWithTitle:@"Connection Error"
-                                           message:message
-                                          delegate:self
-                                 cancelButtonTitle:cancelText
-                                 otherButtonTitles:nil];
-    if (retry) {
-        [alertView addButtonWithTitle:@"Retry"];
-    }
-    [alertView show];
+    [self loadPageFailure:error];
 }
 
-/*
- * Invoked as callback from UIAlertView when prompting the user about connection issues.
- */
-- (void) alertView:(UIAlertView *)view didDismissWithButtonIndex:(NSInteger)buttonIndex
+- (BOOL) isLoading
 {
-    alertView = NULL;
-
-    if(buttonIndex == 1) {
-        userRequestedReload = YES; // Allows us to keep track of the fact that an error may be raised
-        // by the webView as a result of attempting to load a page before the previous request finished.
-
-        NSLog(@"User initiated retry of current request");
-        [self retryCurrentRequest];
-    }
-
-    if (buttonIndex == 0 || buttonIndex == 1) {
-        // In either the case that the user says to wait or retry we always want to reset the timer so that they're
-        // prompted if the request has not completed.  This provides the user a way to get out of a blank screen
-        // on start up.
-        [self startRequestTimer];
-    }
+    UIWebView *uiWebView = [self.plugin findWebView];
+    return uiWebView.loading;
 }
 
-#pragma mark - Subclass callbacks
-
-/*
- * Callback to inform the base base of the start of a page load.
- */
--(void) webViewRequestStart
+- (void) retryCurrentRequest
 {
-    userRequestedReload = NO;
-    [self startRequestTimer];
-}
+    UIWebView *webView = [self.plugin findWebView];
 
-/*
- * Callback to inform the base of a page load failure.
- */
-- (void)loadPageFailure:(NSError *)error
-{
-    NSLog(@"Error loading page: %@", [error description]);
-    
-    if ([error code] == NSURLErrorCancelled) { //ignore if page load didn't complete and user moved away to another page
-        return;
-    }
-
-    if (userRequestedReload == NO && self.plugin.showConnectionErrorDialog == YES) {
-        [self displayRetryPromptWithMessage:@"Unable to contact the site." withCancelText:@"Close" retryable:NO];
-    }
-}
-
-/*
- * Resets the request timer state.  Hides the alert view if it is displayed.
- */
--(void) cancelRequestTimer
-{
-    if (alertView != NULL && alertView.visible == YES) {
-        // Dismiss the alert view.  The assumption is the page finished loading while the view was displayed.
-        [alertView dismissWithClickedButtonIndex:-1 animated:YES];
-        alertView = NULL;
-    }
-    
-    if (lastRequestTime != NULL) {
-        [NSObject cancelPreviousPerformRequestsWithTarget:(id)self selector:@selector(loadProgressCheckCallback:) object:lastRequestTime];
-    }
-    lastRequestTime = NULL;
-}
-
-#pragma mark - Must be implemented by subclass
-
-/*
- * Has to be implemented by subclass to state when a request has been made without yet seeing a response.
- */
--(BOOL) isLoading
-{
-    NSException* myException = [NSException
-                                exceptionWithName:@"MethodNotImplemented"
-                                reason:@"Subclass must implement 'isLoading'."
-                                userInfo:nil];
-    @throw myException;
-}
-
-/*
- * Has to be implemented by the subclass to allow the user to retry a long running request.
- */
--(void) retryCurrentRequest
-{
-    NSException* myException = [NSException
-                                exceptionWithName:@"MethodNotImplemented"
-                                reason:@"Subclass must implement 'retryCurrentRequest'."
-                                userInfo:nil];
-    @throw myException;
+    [webView stopLoading];
+    [webView reload];
 }
 
 @end

--- a/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
+++ b/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
@@ -125,7 +125,31 @@
     NSLog(@"Unsupported scheme for cordova injection: '%@'.  Skipping.", scheme);
     return NO;
 }
-
+    
+    
+/*
+ * Returns YES if is valid URL
+ *
+ */
+- (BOOL) isInjectableSite:(NSString *) url
+{
+    // If no injectable sites, return yes by default
+    if([self.plugin.injectableSites count] <= 0){
+        return YES;
+    }
+    // Available Sites
+    for (id site in self.plugin.injectableSites) {
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: site options: NSRegularExpressionCaseInsensitive error: nil];
+        NSTextCheckingResult *match = [regex firstMatchInString:url options:NSMatchingReportCompletion range: NSMakeRange(0, [site length])];
+        BOOL isMatch = match != nil;
+        if(isMatch){
+            return YES;
+        }
+    }
+    return NO;
+}
+    
+    
 /*
  * Begins a timer to track the progress of a request.
  */

--- a/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
+++ b/src/ios/CDVRemoteInjectionWebViewBaseDelegate.m
@@ -1,106 +1,294 @@
-//
-//  CDVRemoteInjection.m
-//
-
 #import <Foundation/Foundation.h>
 
-#import "CDVRemoteInjectionUIWebViewDelegate.h"
+#import "CDVRemoteInjection.h"
 #import "CDVRemoteInjectionWebViewBaseDelegate.h"
 
+/*
+ Objective-C wonkiness to create a property that can be accessed
+ by subclasses but not on the exported public interface.
+ */
+@interface CDVRemoteInjectionWebViewBaseDelegate ()
+@property (readwrite, weak) CDVRemoteInjectionPlugin *plugin;
+@end
 
-@implementation CDVRemoteInjectionUIWebViewNotificationDelegate
-@dynamic wrappedDelegate;
+@interface CDVRemoteInjectionWebViewBaseDelegate ()
+@end
 
-- (void)webViewDidStartLoad:(UIWebView*)webView
+@implementation WrappedDelegateProxy
+- (BOOL)respondsToSelector:(SEL)aSelector
 {
-    [self.webViewDelegate onWebViewDidStartLoad];
-
-    if ([self.wrappedDelegate respondsToSelector:@selector(webViewDidStartLoad:)]) {
-        [self.wrappedDelegate webViewDidStartLoad:webView];
+    if ([super respondsToSelector:aSelector] || [self.wrappedDelegate respondsToSelector:aSelector]) {
+        return YES;
     }
+    return NO;
 }
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView
+- (void)forwardInvocation:(NSInvocation *)anInvocation
 {
-    [self.webViewDelegate onWebViewDidFinishLoad:webView];
-
-    if ([self.wrappedDelegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
-        [self.wrappedDelegate webViewDidFinishLoad:webView];
-    }
-}
-
-- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
-{
-    if ([self.wrappedDelegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
-        [self.wrappedDelegate webView:webView didFailLoadWithError:error];
-    }
-
-    [self.webViewDelegate onWebViewFailLoadWithError:error];
+    if ([self.wrappedDelegate respondsToSelector:[anInvocation selector]])
+        [anInvocation invokeWithTarget:self.wrappedDelegate];
+    else
+        [super forwardInvocation:anInvocation];
 }
 @end
 
-@implementation CDVRemoteInjectionUIWebViewDelegate
+@implementation CDVRemoteInjectionWebViewBaseDelegate
 {
-    CDVRemoteInjectionUIWebViewNotificationDelegate *notificationDelegate;
+    /*
+     Last time a request was made to load the web view.  Can be NULL.
+     */
+    NSDate *lastRequestTime;
+
+    /*
+     Reference to the currently displayed alert view.  Can be NULL.
+     */
+    UIAlertView *alertView;
+
+    /*
+     True if the user forced a reload.
+     */
+    BOOL userRequestedReload;
 }
 
 - (void)initializeDelegate:(CDVRemoteInjectionPlugin *)plugin
 {
-    self.plugin = plugin;
-
-    // Wrap the current delegate with our own so we can hook into web view events.
-    UIWebView *uiWebView = [plugin findWebView];
-    notificationDelegate = [[CDVRemoteInjectionUIWebViewNotificationDelegate alloc] init];
-    notificationDelegate.wrappedDelegate = [uiWebView delegate];
-    notificationDelegate.webViewDelegate = self;
-    [uiWebView setDelegate:notificationDelegate];
-}
-
--(void) onWebViewDidStartLoad
-{
-    [super webViewRequestStart];
+  // TODO To placate the compiler.
 }
 
 /*
- * After page load inject cordova and its plugins.
+ Builds a string of JS to inject into the web view.
  */
-- (void) onWebViewDidFinishLoad:(UIWebView *)webView
+- (NSString *) buildInjectionJS;
 {
-    // Cancel the slow request timer.
-    [self cancelRequestTimer];
+    NSArray *jsPaths = [self jsPathsToInject];
 
-    // Inject cordova into the page.
-    NSString *scheme = webView.request.URL.scheme;
+    NSString *path;
+    NSMutableString *concatenatedJS = [[NSMutableString alloc] init];
 
-    if ([self isSupportedURLScheme:scheme] && [self isInjectableSite:webView.request.URL.absoluteString]){
-        NSLog(@"Evaluating Javascript for %@",webView.request.URL.absoluteString);
-        NSString *response = [webView stringByEvaluatingJavaScriptFromString: @"window.cordova"];
-        if ([response caseInsensitiveCompare: @"null"] != NSOrderedSame){
-            [webView stringByEvaluatingJavaScriptFromString:[self buildInjectionJS]];
-        }else{
-            NSLog(@"Cordova already defined.");
+    for (path in jsPaths) {
+        NSString *jsFilePath = [[NSBundle mainBundle] pathForResource:path ofType:nil];
+
+        NSURL *jsURL = [NSURL fileURLWithPath:jsFilePath];
+        NSString *js = [NSString stringWithContentsOfFile:jsURL.path encoding:NSUTF8StringEncoding error:nil];
+        NSLog(@"Concatenating JS found in path: '%@'", jsURL.path);
+
+        [concatenatedJS appendString:js];
+    }
+    return concatenatedJS;
+}
+
+/*
+ Returns an array of bundled javascript files to inject into the current page.
+ */
+- (NSArray *) jsPathsToInject
+{
+    // Array of paths that represent JS files to inject into the WebView.  Order is important.
+    NSMutableArray *jsPaths = [NSMutableArray new];
+
+    // Pre injection files.
+    for (id path in self.plugin.injectFirstFiles) {
+        [jsPaths addObject: path];
+    }
+
+    [jsPaths addObject:@"www/cordova.js"];
+
+    // We load the plugin code manually rather than allow cordova to load them (via
+    // cordova_plugins.js).  The reason for this is the WebView will attempt to load the
+    // file in the origin of the page (e.g. https://example.com/plugins/plugin/plugin.js).
+    // By loading them first cordova will skip the loading process altogether.
+    NSDirectoryEnumerator *directoryEnumerator = [[NSFileManager defaultManager] enumeratorAtPath:[[NSBundle mainBundle] pathForResource:@"www/plugins" ofType:nil]];
+
+    NSString *path;
+    while (path = [directoryEnumerator nextObject])
+    {
+        if ([path hasSuffix: @".js"]) {
+            [jsPaths addObject: [NSString stringWithFormat:@"%@/%@", @"www/plugins", path]];
+        }
+    }
+    // Initialize cordova plugin registry.
+    [jsPaths addObject:@"www/cordova_plugins.js"];
+
+    return jsPaths;
+}
+
+/*
+ * Returns YES if the URL scheme is supported for JS injection.
+ *
+ * TODO: possibly expand to check content type
+ */
+- (BOOL) isSupportedURLScheme:(NSString *) scheme
+{
+    if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
+        return YES;
+    }
+
+    NSLog(@"Unsupported scheme for cordova injection: '%@'.  Skipping.", scheme);
+    return NO;
+}
+
+
+/*
+ * Returns YES if is valid URL
+ *
+ */
+- (BOOL) isInjectableSite:(NSString *) url
+{
+    // If no injectable sites, return yes by default
+    if([self.plugin.injectableSites count] <= 0){
+        return YES;
+    }
+    // Available Sites
+    for (id site in self.plugin.injectableSites) {
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: site options: NSRegularExpressionCaseInsensitive error: nil];
+        NSTextCheckingResult *match = [regex firstMatchInString:url options:NSMatchingReportCompletion range: NSMakeRange(0, [site length])];
+        BOOL isMatch = match != nil;
+        if(isMatch){
+            return YES;
+        }
+    }
+    return NO;
+}
+
+
+/*
+ * Begins a timer to track the progress of a request.
+ */
+-(void) startRequestTimer
+{
+    if (self.plugin.promptInterval > 0) {
+        [self cancelRequestTimer];
+        lastRequestTime = [NSDate date];
+
+        // Schedule progress check.
+        NSLog(@"Starting a timer to track page load time that will expire in '%ld' seconds.", (long)self.plugin.promptInterval);
+        [self performSelector:@selector(loadProgressCheckCallback:) withObject:lastRequestTime afterDelay:self.plugin.promptInterval];
+    }
+}
+
+/*
+ * Determines if the user should be prompted because of a long running request.  Displays the prompt.
+ */
+-(void) loadProgressCheckCallback:(id)requestTime
+{
+    // Check equality of the request time to ensure we're still tracking the same request.  If not ignore.
+    if (lastRequestTime != NULL && [(NSDate *)requestTime isEqualToDate:lastRequestTime]) {
+        if ([self isLoading]) {
+            NSLog(@"Request taking too long, displaying dialog.");
+            [self displayRetryPromptWithMessage:@"The server is taking longer than expected to respond." withCancelText:@"Wait" retryable:YES];
+            return;
+        } else {
+            NSLog(@"No request in progress.  Not displaying dialog.");
         }
     }
 }
 
-// Handles notifications from the webview delegate whenever a page load fails.
-- (void) onWebViewFailLoadWithError:(NSError *)error
+/*
+ Prompts the user providing them a choice to retry the latest request or wait.
+ */
+-(void) displayRetryPromptWithMessage:(NSString*)message withCancelText:(NSString *)cancelText retryable:(BOOL) retry
 {
-    [self loadPageFailure:error];
+    alertView = [[UIAlertView alloc] initWithTitle:@"Connection Error"
+                                           message:message
+                                          delegate:self
+                                 cancelButtonTitle:cancelText
+                                 otherButtonTitles:nil];
+    if (retry) {
+        [alertView addButtonWithTitle:@"Retry"];
+    }
+    [alertView show];
 }
 
-- (BOOL) isLoading
+/*
+ * Invoked as callback from UIAlertView when prompting the user about connection issues.
+ */
+- (void) alertView:(UIAlertView *)view didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    UIWebView *uiWebView = [self.plugin findWebView];
-    return uiWebView.loading;
+    alertView = NULL;
+
+    if(buttonIndex == 1) {
+        userRequestedReload = YES; // Allows us to keep track of the fact that an error may be raised
+        // by the webView as a result of attempting to load a page before the previous request finished.
+
+        NSLog(@"User initiated retry of current request");
+        [self retryCurrentRequest];
+    }
+
+    if (buttonIndex == 0 || buttonIndex == 1) {
+        // In either the case that the user says to wait or retry we always want to reset the timer so that they're
+        // prompted if the request has not completed.  This provides the user a way to get out of a blank screen
+        // on start up.
+        [self startRequestTimer];
+    }
 }
 
-- (void) retryCurrentRequest
-{
-    UIWebView *webView = [self.plugin findWebView];
+#pragma mark - Subclass callbacks
 
-    [webView stopLoading];
-    [webView reload];
+/*
+ * Callback to inform the base base of the start of a page load.
+ */
+-(void) webViewRequestStart
+{
+    userRequestedReload = NO;
+    [self startRequestTimer];
+}
+
+/*
+ * Callback to inform the base of a page load failure.
+ */
+- (void)loadPageFailure:(NSError *)error
+{
+    NSLog(@"Error loading page: %@", [error description]);
+
+    if ([error code] == NSURLErrorCancelled) { //ignore if page load didn't complete and user moved away to another page
+        return;
+    }
+
+    if (userRequestedReload == NO && self.plugin.showConnectionErrorDialog == YES) {
+        [self displayRetryPromptWithMessage:@"Unable to contact the site." withCancelText:@"Close" retryable:NO];
+    }
+}
+
+/*
+ * Resets the request timer state.  Hides the alert view if it is displayed.
+ */
+-(void) cancelRequestTimer
+{
+    if (alertView != NULL && alertView.visible == YES) {
+        // Dismiss the alert view.  The assumption is the page finished loading while the view was displayed.
+        [alertView dismissWithClickedButtonIndex:-1 animated:YES];
+        alertView = NULL;
+    }
+
+    if (lastRequestTime != NULL) {
+        [NSObject cancelPreviousPerformRequestsWithTarget:(id)self selector:@selector(loadProgressCheckCallback:) object:lastRequestTime];
+    }
+    lastRequestTime = NULL;
+}
+
+#pragma mark - Must be implemented by subclass
+
+/*
+ * Has to be implemented by subclass to state when a request has been made without yet seeing a response.
+ */
+-(BOOL) isLoading
+{
+    NSException* myException = [NSException
+                                exceptionWithName:@"MethodNotImplemented"
+                                reason:@"Subclass must implement 'isLoading'."
+                                userInfo:nil];
+    @throw myException;
+}
+
+/*
+ * Has to be implemented by the subclass to allow the user to retry a long running request.
+ */
+-(void) retryCurrentRequest
+{
+    NSException* myException = [NSException
+                                exceptionWithName:@"MethodNotImplemented"
+                                reason:@"Subclass must implement 'retryCurrentRequest'."
+                                userInfo:nil];
+    @throw myException;
 }
 
 @end


### PR DESCRIPTION
I made a few changes to assist in Cordova-wrapping an SPA, and I thought the changes may be beneficial to someone else.

1. Add an CRIInjectableSites preference that accepts wildcard URLs. This prevents the javascript from being injected on every request. It seems like a preventive measure to ensure JS is not injected where it is not wanted.

2. Add a window.cordova == null check to prevent Cordova from being injected multiple times. I have found this occurs when making asynchronous web calls from the initial page.

Let me know what you think. Thanks! 