### PR TITLE
`WKWebViewOnly` setting for removing UIWebView

### DIFF
--- a/src/ios/CDVRemoteInjection.m
+++ b/src/ios/CDVRemoteInjection.m
@@ -81,6 +81,10 @@
     }
 
     id webView = [self findWebView];
+    #if WK_WEB_VIEW_ONLY
+        webViewDelegate = [[CDVRemoteInjectionWKWebViewDelegate alloc] init];
+        [webViewDelegate initializeDelegate:self];
+    #else
     if ([webView isKindOfClass:[UIWebView class]]) {
         NSLog(@"Found UIWebView");
         webViewDelegate = [[CDVRemoteInjectionUIWebViewDelegate alloc] init];
@@ -96,6 +100,7 @@
     } else {
         NSLog(@"Not a supported web view implementation");
     }
+    #endif
 }
 
 /*

--- a/src/ios/CDVRemoteInjectionUIWebViewDelegate.h
+++ b/src/ios/CDVRemoteInjectionUIWebViewDelegate.h
@@ -1,3 +1,5 @@
+#if !WK_WEB_VIEW_ONLY
+
 #import "CDVRemoteInjection.h"
 #import "CDVRemoteInjectionWebViewBaseDelegate.h"
 
@@ -11,3 +13,5 @@
 @interface CDVRemoteInjectionUIWebViewNotificationDelegate : WrappedDelegateProxy <UIWebViewDelegate>
 @property (readwrite, weak) CDVRemoteInjectionUIWebViewDelegate *webViewDelegate;
 @end
+
+#endif

--- a/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
+++ b/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
@@ -2,6 +2,8 @@
 //  CDVRemoteInjection.m
 //
 
+#if !WK_WEB_VIEW_ONLY
+
 #import <Foundation/Foundation.h>
 
 #import "CDVRemoteInjectionUIWebViewDelegate.h"
@@ -98,3 +100,5 @@
 }
 
 @end
+
+#endif


### PR DESCRIPTION
I know that PRs won't be merged in this repo, but adding this here for visibility.
See Issue #46 

The most straightforward way to fix the UIWebView deprecation issue is to remove all the related code. Several forks have done this; see:

- https://github.com/vinq1911/cordova-plugin-remote-injection/commit/ff15458180cbe65d1266fed6211ee6aaa355f4a3
- https://github.com/ipunkvizard/cordova-plugin-remote-injection/commit/5a027eed3e15176dabdd85a0f779643b3b10912a
- https://github.com/RobertY9/cordova-plugin-remote-injection/commit/90ea30441bfa1f1ce5fa9d7b3baacc69c1405eb2

This PR takes the same approach as `cordova-ios` and `cordova-plugin-inappbrowser`, implementing conditional compilation based on the `WKWebViewOnly` config.xml setting. See [Cordova article here for more information](https://cordova.apache.org/howto/2020/03/18/wkwebviewonly.html).

Adding `<preference name="WKWebViewOnly" value="true" />` to the ios platform in config.xml will cause UIWebView code to be removed.

However.. maybe the "remove-all" approach is better? Why do we ever need UIWebView code around now? This change does represent fewer lines changed, so maybe that's something.

---

This change can also be pulled in using [`patch-package`](https://github.com/ds300/patch-package):

**`patches/cordova-plugin-remote-injection+0.5.2.patch`**
```
diff --git a/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjection.m b/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjection.m
index 9c11eb9..7a72cb2 100644
--- a/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjection.m
+++ b/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjection.m
@@ -81,6 +81,10 @@ - (void) pluginInitialize
     }
 
     id webView = [self findWebView];
+    #if WK_WEB_VIEW_ONLY
+        webViewDelegate = [[CDVRemoteInjectionWKWebViewDelegate alloc] init];
+        [webViewDelegate initializeDelegate:self];
+    #else
     if ([webView isKindOfClass:[UIWebView class]]) {
         NSLog(@"Found UIWebView");
         webViewDelegate = [[CDVRemoteInjectionUIWebViewDelegate alloc] init];
@@ -96,6 +100,7 @@ - (void) pluginInitialize
     } else {
         NSLog(@"Not a supported web view implementation");
     }
+    #endif
 }
 
 /*
diff --git a/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.h b/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.h
index b451824..3967ca9 100644
--- a/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.h
+++ b/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.h
@@ -1,3 +1,5 @@
+#if !WK_WEB_VIEW_ONLY
+
 #import "CDVRemoteInjection.h"
 #import "CDVRemoteInjectionWebViewBaseDelegate.h"
 
@@ -11,3 +13,5 @@
 @interface CDVRemoteInjectionUIWebViewNotificationDelegate : WrappedDelegateProxy <UIWebViewDelegate>
 @property (readwrite, weak) CDVRemoteInjectionUIWebViewDelegate *webViewDelegate;
 @end
+
+#endif
diff --git a/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.m b/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
index bb0251e..d1c0dd4 100644
--- a/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
+++ b/node_modules/cordova-plugin-remote-injection/src/ios/CDVRemoteInjectionUIWebViewDelegate.m
@@ -2,6 +2,8 @@
 //  CDVRemoteInjection.m
 //
 
+#if !WK_WEB_VIEW_ONLY
+
 #import <Foundation/Foundation.h>
 
 #import "CDVRemoteInjectionUIWebViewDelegate.h"
@@ -98,3 +100,5 @@ - (void) retryCurrentRequest
 }
 
 @end
+
+#endif

```